### PR TITLE
Upgraded SimpleInjector dependency to 4.x , removed dependency on SimpleInjector.Extensions.LifetimeScoping

### DIFF
--- a/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Program.cs
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Program.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Quartz;
 using SimpleInjector;
+using SimpleInjector.Lifestyles;
 
 namespace Topshelf.SimpleInjector.Quartz.Decorators.Sample
 {
@@ -107,7 +108,7 @@ namespace Topshelf.SimpleInjector.Quartz.Decorators.Sample
 
             public void Execute(IJobExecutionContext context)
             {
-                using (_container.BeginLifetimeScope())
+                using (ThreadScopedLifestyle.BeginScope(_container))
                 {
                     Console.WriteLine("See, i am decorating the Job: " + typeof(JobWithInjectedDependenciesDecorated).Name + " with a Lifetime Scope!");
                     var job = _decorateeFactory.Invoke();

--- a/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Program.cs
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Program.cs
@@ -14,7 +14,7 @@ namespace Topshelf.SimpleInjector.Quartz.Decorators.Sample
         {
             _container.Register<IDependencyInjected, DependencyInjected>();
             _container.RegisterDecorator(typeof(IJob), typeof(LoggingDecorator));
-            _container.RegisterDecorator(typeof(IJob), typeof(LifetimeScopeDecoratorFuncTFactory));
+            _container.RegisterDecorator(typeof(IJob), typeof(ThreadScopedDecoratorFuncTFactory));
 
             HostFactory.Run(config =>
             {
@@ -95,12 +95,12 @@ namespace Topshelf.SimpleInjector.Quartz.Decorators.Sample
             }
         }
 
-        public class LifetimeScopeDecoratorFuncTFactory : IJob
+        public class ThreadScopedDecoratorFuncTFactory : IJob
         {
             private readonly Func<IJob> _decorateeFactory;
             private readonly Container _container;
 
-            public LifetimeScopeDecoratorFuncTFactory(Func<IJob> decorateeFactory, Container container)
+            public ThreadScopedDecoratorFuncTFactory(Func<IJob> decorateeFactory, Container container)
             {
                 _decorateeFactory = decorateeFactory;
                 _container = container;
@@ -110,7 +110,7 @@ namespace Topshelf.SimpleInjector.Quartz.Decorators.Sample
             {
                 using (ThreadScopedLifestyle.BeginScope(_container))
                 {
-                    Console.WriteLine("See, i am decorating the Job: " + typeof(JobWithInjectedDependenciesDecorated).Name + " with a Lifetime Scope!");
+                    Console.WriteLine("See, i am decorating the Job: " + typeof(JobWithInjectedDependenciesDecorated).Name + " with a Thread Scope!");
                     var job = _decorateeFactory.Invoke();
                     job.Execute(context);
                 }

--- a/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Topshelf.SimpleInjector.Quartz.Decorators.Sample.csproj
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/Topshelf.SimpleInjector.Quartz.Decorators.Sample.csproj
@@ -45,12 +45,8 @@
       <HintPath>..\..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SimpleInjector.Extensions.LifetimeScoping, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.Extensions.LifetimeScoping.3.1.2\lib\net40-client\SimpleInjector.Extensions.LifetimeScoping.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -70,7 +66,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -94,4 +92,3 @@
   </Target>
   -->
 </Project>
-

--- a/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/app.config
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.7.0" newVersion="4.0.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/packages.config
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Decorators.Sample/packages.config
@@ -3,7 +3,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
-  <package id="SimpleInjector.Extensions.LifetimeScoping" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>

--- a/Samples/Topshelf.SimpleInjector.Quartz.Sample/Program.cs
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Sample/Program.cs
@@ -29,7 +29,7 @@ namespace Topshelf.SimpleInjector.Quartz.Sample
                             new
                             {
                                 type,
-                                ctor = _container.Options.ConstructorResolutionBehavior.GetConstructor(typeof(IJob), type)
+                                ctor = _container.Options.ConstructorResolutionBehavior.GetConstructor(type)
                             })
                     .Select(
                         type =>

--- a/Samples/Topshelf.SimpleInjector.Quartz.Sample/Topshelf.SimpleInjector.Quartz.Sample.csproj
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Sample/Topshelf.SimpleInjector.Quartz.Sample.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -76,7 +76,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
@@ -88,4 +90,3 @@
   </Target>
   -->
 </Project>
-

--- a/Samples/Topshelf.SimpleInjector.Quartz.Sample/app.config
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Sample/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.7.0" newVersion="4.0.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Samples/Topshelf.SimpleInjector.Quartz.Sample/packages.config
+++ b/Samples/Topshelf.SimpleInjector.Quartz.Sample/packages.config
@@ -3,6 +3,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>

--- a/Samples/Topshelf.SimpleInjector.QuartzAsService.Sample/Topshelf.SimpleInjector.QuartzAsService.Sample.csproj
+++ b/Samples/Topshelf.SimpleInjector.QuartzAsService.Sample/Topshelf.SimpleInjector.QuartzAsService.Sample.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -89,4 +89,3 @@
   </Target>
   -->
 </Project>
-

--- a/Samples/Topshelf.SimpleInjector.QuartzAsService.Sample/packages.config
+++ b/Samples/Topshelf.SimpleInjector.QuartzAsService.Sample/packages.config
@@ -3,6 +3,6 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net45" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net45" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>

--- a/Samples/Topshelf.SimpleInjector.Sample/Topshelf.SimpleInjector.Sample.csproj
+++ b/Samples/Topshelf.SimpleInjector.Sample/Topshelf.SimpleInjector.Sample.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -72,4 +72,3 @@
   </Target>
   -->
 </Project>
-

--- a/Samples/Topshelf.SimpleInjector.Sample/packages.config
+++ b/Samples/Topshelf.SimpleInjector.Sample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>

--- a/Source/Topshelf.SimpleInjector.Quartz/Factory/SimpleInjectorDecoratorJobFactory.cs
+++ b/Source/Topshelf.SimpleInjector.Quartz/Factory/SimpleInjectorDecoratorJobFactory.cs
@@ -33,7 +33,7 @@ namespace Topshelf.SimpleInjector.Quartz.Factory
                 from type in assembly.GetTypes()
                 where typeof(IJob).IsAssignableFrom(type)
                 where !type.IsAbstract && !type.IsGenericTypeDefinition
-                let ctor = container.Options.ConstructorResolutionBehavior.GetConstructor(typeof(IJob), type)
+                let ctor = container.Options.ConstructorResolutionBehavior.GetConstructor(type)
                 let typeIsDecorator = ctor.GetParameters().Any(p => p.ParameterType == typeof(IJob))
                 let typeIsDecorateeFactory = ctor.GetParameters().Any(p => p.ParameterType == typeof(Func<IJob>))
                 where !typeIsDecorator && !typeIsDecorateeFactory

--- a/Source/Topshelf.SimpleInjector.Quartz/Topshelf.SimpleInjector.Quartz.csproj
+++ b/Source/Topshelf.SimpleInjector.Quartz/Topshelf.SimpleInjector.Quartz.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net40\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -81,6 +81,7 @@
     <Compile Include="SimpleInjectorScheduleJobHostConfiguratorExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Topshelf.SimpleInjector.Quartz.nuspec">
       <SubType>Designer</SubType>

--- a/Source/Topshelf.SimpleInjector.Quartz/app.config
+++ b/Source/Topshelf.SimpleInjector.Quartz/app.config
@@ -3,20 +3,16 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <assemblyIdentity name="Common.Logging" publicKeyToken="af08829b84f0328e" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.3.1.0" newVersion="3.3.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.7.0" newVersion="4.0.7.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.3.154.0" newVersion="3.3.154.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Source/Topshelf.SimpleInjector.Quartz/packages.config
+++ b/Source/Topshelf.SimpleInjector.Quartz/packages.config
@@ -3,7 +3,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net4" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net4" />
   <package id="Quartz" version="2.3.3" targetFramework="net4" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net4" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
   <package id="Topshelf" version="3.3.1" targetFramework="net4" />
   <package id="Topshelf.SimpleInjector" version="1.0.0.16" targetFramework="net40" />
 </packages>

--- a/Source/Topshelf.SimpleInjector.QuickStart/Topshelf.SimpleInjector.QuickStart.csproj
+++ b/Source/Topshelf.SimpleInjector.QuickStart/Topshelf.SimpleInjector.QuickStart.csproj
@@ -35,8 +35,8 @@
   </PropertyGroup>
   <PropertyGroup />
   <ItemGroup>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net40\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -63,6 +63,7 @@
     <Compile Include="Content\Service.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Topshelf.SimpleInjector.QuickStart.nuspec" />
   </ItemGroup>

--- a/Source/Topshelf.SimpleInjector.QuickStart/app.config
+++ b/Source/Topshelf.SimpleInjector.QuickStart/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.7.0" newVersion="4.0.7.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/Topshelf.SimpleInjector.QuickStart/packages.config
+++ b/Source/Topshelf.SimpleInjector.QuickStart/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net4" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
   <package id="Topshelf" version="3.3.1" targetFramework="net4" />
   <package id="Topshelf.SimpleInjector" version="1.0.0.16" targetFramework="net40" />
 </packages>

--- a/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.csproj
+++ b/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net40-client\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net40\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -67,4 +67,3 @@
   </Target>
   -->
 </Project>
-

--- a/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.nuspec
+++ b/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright $author$ 2014</copyright>
     <tags>Topshelf SimpleInjector IoC Inversion-of-control Service WindowsService Dependency Injection DI Host</tags>
     <dependencies>
-      <dependency id="SimpleInjector" version="3.1.2" />
+      <dependency id="SimpleInjector" version="4.0.0" />
       <dependency id="Topshelf" version="3.3.1" />
     </dependencies>
   </metadata>

--- a/Source/Topshelf.SimpleInjector/packages.config
+++ b/Source/Topshelf.SimpleInjector/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net4" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
   <package id="Topshelf" version="3.3.1" targetFramework="net4" />
 </packages>

--- a/Tests/Topshelf.SimpleInjector.Quartz.Test/Topshelf.SimpleInjector.Quartz.Test.csproj
+++ b/Tests/Topshelf.SimpleInjector.Quartz.Test/Topshelf.SimpleInjector.Quartz.Test.csproj
@@ -55,8 +55,8 @@
       <HintPath>..\..\packages\Quartz.2.3.3\lib\net40\Quartz.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -98,4 +98,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Topshelf.SimpleInjector.Quartz.Test/app.config
+++ b/Tests/Topshelf.SimpleInjector.Quartz.Test/app.config
@@ -12,7 +12,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="SimpleInjector" publicKeyToken="984cb50dea722e99" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.7.0" newVersion="4.0.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Topshelf" publicKeyToken="b800c4cfcdeea87b" culture="neutral" />

--- a/Tests/Topshelf.SimpleInjector.Quartz.Test/packages.config
+++ b/Tests/Topshelf.SimpleInjector.Quartz.Test/packages.config
@@ -6,6 +6,6 @@
   <package id="NUnit" version="3.0.1" targetFramework="net45" />
   <package id="NUnit.ApplicationDomain" version="6.0.0" targetFramework="net45" />
   <package id="Quartz" version="2.3.3" targetFramework="net45" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>

--- a/Tests/Topshelf.SimpleInjector.Test/Topshelf.SimpleInjector.Test.csproj
+++ b/Tests/Topshelf.SimpleInjector.Test/Topshelf.SimpleInjector.Test.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\..\packages\NUnit.3.0.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SimpleInjector, Version=3.1.2.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.3.1.2\lib\net45\SimpleInjector.dll</HintPath>
+    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -78,4 +78,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Topshelf.SimpleInjector.Test/packages.config
+++ b/Tests/Topshelf.SimpleInjector.Test/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="NUnit" version="3.0.1" targetFramework="net45" />
   <package id="NUnit.ApplicationDomain" version="6.0.0" targetFramework="net45" />
-  <package id="SimpleInjector" version="3.1.2" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="3.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I created this PR because I can't use Topshelf.Simpleinjector with Simpleinjector 4.x, and it seems to me it is only because of minor API changes.

Upgraded SimpleInjector dependency to 4.x.
Removed dependency on SimpleInjector.Extensions.LifetimeScoping.
Replaced usages of removed two-argument IConstructorResolutionBehavior.GetConstructor method with single argument one.
Replaced usages of LifetimeScoping with ThreadScopedLifestyle, as LifetimeScoping has been deprecated.

https://github.com/simpleinjector/SimpleInjector/releases/tag/v4.0

> IConstructorResolutionBehavior.GetConstructor(Type, Type) signature changed to
GetConstructor(Type). (fixes #345)

> SimpleInjector.Extensions.LifetimeScoping
This package has been deprecated and will no longer be maintained. All functionality has been merged into the core library. (fixes #299)
LifetimeScopeLifestyle has been deprecated. Users should use the new SimpleInjector.Lifestyles.ThreadScopedLifestyle. (fixes #299)

I can't get the FileSystemWatcher-tests to run on my machine, troubles with file system permissions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tynor88/topshelf.simpleinjector/20)
<!-- Reviewable:end -->
