### PR TITLE
Feature/simpleinjector upgrade

### DIFF
--- a/Samples/Topshelf.SimpleInjector.Sample/Topshelf.SimpleInjector.Sample.csproj
+++ b/Samples/Topshelf.SimpleInjector.Sample/Topshelf.SimpleInjector.Sample.csproj
@@ -34,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SimpleInjector, Version=4.3.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.3.0\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Samples/Topshelf.SimpleInjector.Sample/packages.config
+++ b/Samples/Topshelf.SimpleInjector.Sample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.3.0" targetFramework="net452" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
 </packages>

--- a/Source/Topshelf.SimpleInjector.Quartz/Topshelf.SimpleInjector.Quartz.csproj
+++ b/Source/Topshelf.SimpleInjector.Quartz/Topshelf.SimpleInjector.Quartz.csproj
@@ -64,8 +64,8 @@
     <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Topshelf.4.0.3\lib\net452\Topshelf.dll</HintPath>
     </Reference>
-    <Reference Include="Topshelf.SimpleInjector, Version=1.0.0.17, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Topshelf.SimpleInjector.1.0.0.17\lib\net40\Topshelf.SimpleInjector.dll</HintPath>
+    <Reference Include="Topshelf.SimpleInjector, Version=1.0.0.20, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Topshelf.SimpleInjector.1.0.0.20\lib\net452\Topshelf.SimpleInjector.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Topshelf.SimpleInjector.Quartz/packages.config
+++ b/Source/Topshelf.SimpleInjector.Quartz/packages.config
@@ -5,5 +5,5 @@
   <package id="Quartz" version="2.5.0" targetFramework="net452" />
   <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
-  <package id="Topshelf.SimpleInjector" version="1.0.0.17" targetFramework="net452" />
+  <package id="Topshelf.SimpleInjector" version="1.0.0.20" targetFramework="net452" />
 </packages>

--- a/Source/Topshelf.SimpleInjector.QuickStart/Topshelf.SimpleInjector.QuickStart.csproj
+++ b/Source/Topshelf.SimpleInjector.QuickStart/Topshelf.SimpleInjector.QuickStart.csproj
@@ -51,8 +51,8 @@
     <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Topshelf.4.0.3\lib\net452\Topshelf.dll</HintPath>
     </Reference>
-    <Reference Include="Topshelf.SimpleInjector, Version=1.0.0.17, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Topshelf.SimpleInjector.1.0.0.17\lib\net40\Topshelf.SimpleInjector.dll</HintPath>
+    <Reference Include="Topshelf.SimpleInjector, Version=1.0.0.20, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Topshelf.SimpleInjector.1.0.0.20\lib\net452\Topshelf.SimpleInjector.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Topshelf.SimpleInjector.QuickStart/packages.config
+++ b/Source/Topshelf.SimpleInjector.QuickStart/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
-  <package id="Topshelf.SimpleInjector" version="1.0.0.17" targetFramework="net452" />
+  <package id="Topshelf.SimpleInjector" version="1.0.0.20" targetFramework="net452" />
 </packages>

--- a/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.csproj
+++ b/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.csproj
@@ -34,9 +34,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net40\SimpleInjector.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SimpleInjector, Version=4.3.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.3.0\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.nuspec
+++ b/Source/Topshelf.SimpleInjector/Topshelf.SimpleInjector.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright $author$ 2014</copyright>
     <tags>Topshelf SimpleInjector IoC Inversion-of-control Service WindowsService Dependency Injection DI Host</tags>
     <dependencies>
-      <dependency id="SimpleInjector" version="4.0.0" />
+      <dependency id="SimpleInjector" version="4.3.0" />
       <dependency id="Topshelf" version="4.0.0" />
     </dependencies>
   </metadata>

--- a/Source/Topshelf.SimpleInjector/packages.config
+++ b/Source/Topshelf.SimpleInjector/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SimpleInjector" version="4.0.7" targetFramework="net40" />
+  <package id="SimpleInjector" version="4.3.0" targetFramework="net452" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
 </packages>

--- a/Tests/Topshelf.SimpleInjector.Quartz.Test/Topshelf.SimpleInjector.Quartz.Test.csproj
+++ b/Tests/Topshelf.SimpleInjector.Quartz.Test/Topshelf.SimpleInjector.Quartz.Test.csproj
@@ -70,6 +70,9 @@
     <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Topshelf.4.0.3\lib\net452\Topshelf.dll</HintPath>
     </Reference>
+    <Reference Include="Topshelf.SimpleInjector, Version=1.0.0.20, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Topshelf.SimpleInjector.1.0.0.20\lib\net452\Topshelf.SimpleInjector.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="TopshelfSimpleInjectorQuartzTest.cs" />
@@ -79,10 +82,6 @@
     <ProjectReference Include="..\..\Source\Topshelf.SimpleInjector.Quartz\Topshelf.SimpleInjector.Quartz.csproj">
       <Project>{2fa9135c-12ad-47ce-9a46-4b5bdc1e6032}</Project>
       <Name>Topshelf.SimpleInjector.Quartz</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Source\Topshelf.SimpleInjector\Topshelf.SimpleInjector.csproj">
-      <Project>{b4e07581-5fff-404d-8bbe-6e0b19ef00b6}</Project>
-      <Name>Topshelf.SimpleInjector</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Topshelf.SimpleInjector.Quartz.Test/packages.config
+++ b/Tests/Topshelf.SimpleInjector.Quartz.Test/packages.config
@@ -9,4 +9,5 @@
   <package id="Quartz" version="2.5.0" targetFramework="net452" />
   <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
+  <package id="Topshelf.SimpleInjector" version="1.0.0.20" targetFramework="net452" />
 </packages>

--- a/Tests/Topshelf.SimpleInjector.Test/Topshelf.SimpleInjector.Test.csproj
+++ b/Tests/Topshelf.SimpleInjector.Test/Topshelf.SimpleInjector.Test.csproj
@@ -38,9 +38,8 @@
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="SimpleInjector, Version=4.0.7.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SimpleInjector.4.0.7\lib\net45\SimpleInjector.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SimpleInjector, Version=4.3.0.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SimpleInjector.4.3.0\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tests/Topshelf.SimpleInjector.Test/packages.config
+++ b/Tests/Topshelf.SimpleInjector.Test/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="NUnit.ApplicationDomain" version="10.2.0" targetFramework="net452" />
-  <package id="SimpleInjector" version="4.0.7" targetFramework="net45" />
+  <package id="SimpleInjector" version="4.3.0" targetFramework="net452" />
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I splitted mega pull request to smaller ones.
First thing first - updated SimpleInjecto.
As Topshelf.SimpleInjector is used as dependency in Topshelf.SimpleInjector..Quartz I had to change hard reference to project Topshelf.SimpleInjector  in Topshelf.SimpleInjector.Quartz.Test to nuget package.
Please consider release that package in nuget with version 2.0.0 as this is major breaking change (in SimpleInjetor 4.3 there are few things like for example RegisterInstance instead of RegisterSingleton).
@tynor88 could you please review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tynor88/topshelf.simpleinjector/30)
<!-- Reviewable:end -->
